### PR TITLE
ci: add NextBSD build target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -128,3 +128,47 @@ jobs:
           name: gershwin-debian-x86_64
           path: artifacts/Debian/x86_64
           if-no-files-found: error
+
+  build-nextbsd-amd64:
+    name: NextBSD x86_64
+    runs-on: ubuntu-latest
+    timeout-minutes: 240
+    steps:
+      - uses: actions/checkout@v4
+
+      # No NextBSD runner/container exists, so build inside a chroot of the
+      # latest NextBSD disk image, from a FreeBSD VM.
+      - name: Build inside NextBSD rootfs (FreeBSD VM)
+        uses: vmactions/freebsd-vm@v1
+        with:
+          release: "15.0"
+          usesh: true
+          sync: rsync
+          cpu: 4
+          mem: 8192
+          prepare: |
+            pkg install -y jq unzip
+          run: |
+            set -e
+            REPO=$PWD
+            WORK=/var/tmp/nbsd
+            ROOTFS=$WORK/rootfs
+            mkdir -p "$WORK" "$ROOTFS"
+            URL=$(fetch -qo - https://api.github.com/repos/nextbsd-redux/nextbsd/releases/tags/continuous | jq -r '.assets[] | select(.name | test("amd64.*\\.img\\.zip$")) | .browser_download_url' | head -1)
+            fetch -o "$WORK/nextbsd.img.zip" "$URL"
+            fetch -o "$WORK/nextbsd.img.zip.sha256" "$URL.sha256"
+            [ "$(grep -Eo '[0-9a-f]{64}' "$WORK/nextbsd.img.zip.sha256" | head -1)" = "$(sha256 -q "$WORK/nextbsd.img.zip")" ]
+            unzip -p "$WORK/nextbsd.img.zip" '*.img' > "$WORK/nextbsd.img"
+            md=$(mdconfig -a -t vnode -f "$WORK/nextbsd.img")
+            mount "/dev/${md}p3" /mnt
+            tar -C /mnt -cf - . | tar -C "$ROOTFS" -xpf -
+            umount /mnt
+            mdconfig -d -u "${md#md}"
+            mount -t devfs devfs "$ROOTFS/dev"
+            mkdir -p "$ROOTFS/private/etc"
+            cp /etc/resolv.conf "$ROOTFS/private/etc/resolv.conf"
+            mkdir -p "$ROOTFS/build"
+            tar -C "$REPO" -cf - . | tar -C "$ROOTFS/build" -xpf -
+            chroot "$ROOTFS" /bin/sh -e -c 'cd /build && sh Library/Scripts/Bootstrap.sh && pkg install -y git && sh Library/Scripts/Checkout.sh && make install'
+            umount "$ROOTFS/dev" || true
+            [ -d "$ROOTFS/System/Library" ]


### PR DESCRIPTION
Adds a fourth CI target — **NextBSD x86_64** — alongside FreeBSD, Arch, and Debian.

### Why it's different from the other jobs
NextBSD has no GitHub-hosted runner and no container image, and `vmactions` can't boot its disk image. So instead of the usual "container + Bootstrap + make install", this job manufactures a NextBSD environment: from a FreeBSD VM it downloads the latest NextBSD `continuous` `.img.zip`, mounts its read-write UFS root, and runs the normal `Bootstrap → Checkout → make install` flow inside a `chroot` of it. This mirrors how NextBSD itself builds its Apple userland.

### Notes / first-run unknowns
- **Expected to fail** until NextBSD catches up — this lands the harness so the build is tracked as NextBSD evolves.
- `release: "15.0"` is chosen to match NextBSD's FreeBSD base; adjust if it diverges.
- Assumes the UFS root is GPT partition `p3` (p1 boot, p2 EFI) — confirm from the first run's `gpart show`.
- The chief risk is `configure`-time probe binaries that need a Mach syscall (`mach.ko`) executing under the FreeBSD VM kernel; if that bites, the fallback is a qemu-KVM boot + in-guest build.
- VM disk headroom (image + rootfs copy + build) is the other thing to watch on the first run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)