### PR TITLE
Drop pkgwrap from the component build

### DIFF
--- a/Library/Scripts/Install-System-Domain.sh
+++ b/Library/Scripts/Install-System-Domain.sh
@@ -277,11 +277,6 @@ build_components() {
   $MAKE_CMD install
   $MAKE_CMD clean
 
-  cd "$REPOS_DIR/gershwin-components/pkgwrap"
-  $MAKE_CMD CPPFLAGS="-DGNUSTEP_INSTALL_TYPE=SYSTEM" -j"$CPUS" || exit 1
-  $MAKE_CMD install
-  $MAKE_CMD clean
-
   cd "$REPOS_DIR/gershwin-components/Display"
   $MAKE_CMD CPPFLAGS="-DGNUSTEP_INSTALL_TYPE=SYSTEM" -j"$CPUS" || exit 1
   $MAKE_CMD install


### PR DESCRIPTION
## What

Removes the `pkgwrap` build step from `build_components` in `Install-System-Domain.sh`.

## Why

`pkgwrap` is being removed from gershwin-components (gershwin-desktop/gershwin-components#80) — it was a Linux/apt-specific experiment (`LD_PRELOAD` path-redirect to bundle apt packages) that doesn't fit a cross-platform desktop. With the directory gone, the build must no longer try to `cd .../gershwin-components/pkgwrap`.

## Merge order

**Merge this first**, before the gershwin-components removal (#80), so the per-platform builds (FreeBSD/Arch/Debian and the OpenBSD port) don't fail looking for the deleted directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)