### PR TITLE
docs: OpenBSD support, build targets, and SKIP_REPOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ This is intended for Gershwin developers only.  For more stable packaging with a
 
 * FreeBSD
 * GhostBSD (requires `pkg install -g 'GhostBSD*-dev'` for building)
+* OpenBSD
 * Arch Linux
 * Artix (Arch Linux without systemd)
 * Debian

--- a/README.md
+++ b/README.md
@@ -64,3 +64,41 @@ service loginwindow enable && service loginwindow start
 ## Optional libraries
 * libdbus for waiting for the Global Menu to appear and for implementing the FileManager1 service that lets, e.g., web browsers, open the file manager to show the downloaded files
 * libsquashfs for AppImage icons
+
+## Build targets
+
+`make install` builds and installs the entire system domain. The build is also
+split into granular targets so a single component can be (re)built on its own —
+useful for CI and incremental development. Every per-component target requires
+the core libraries to be installed first (`make corelibs`). All targets run as
+root, like `make install`.
+
+| Target | Builds |
+| --- | --- |
+| `corelibs` | core libraries (libdispatch, libobjc2, tools-make, libs-base, libs-gui, libs-back) plus gershwin-system, gershwin-assets and the plistupdate hook |
+| `workspace` | gershwin-workspace |
+| `systempreferences` | gershwin-systempreferences |
+| `eau-theme` | gershwin-eau-theme |
+| `terminal` | gershwin-terminal |
+| `textedit` | gershwin-textedit |
+| `windowmanager` | gershwin-windowmanager |
+| `components` | gershwin-components (Menu, DirectoryServices, LoginWindow, …) |
+
+For example, build the core libraries once and then just (re)build the workspace:
+
+```
+cd /Developer
+make corelibs
+make workspace
+```
+
+## Skipping repositories during checkout
+
+`Checkout.sh` clones every repository the build needs. Set `SKIP_REPOS` to a
+space- or comma-separated list of repository names to skip cloning/updating some
+of them — handy when you provide a repository's sources yourself (for example a
+CI checkout of the component under test, symlinked into `Library/Sources/`):
+
+```
+SKIP_REPOS="gershwin-workspace gershwin-terminal" /Developer/Library/Scripts/Checkout.sh
+```


### PR DESCRIPTION
## What

README documentation updates (docs-only; commits carry `[skip ci]`):

1. **Supported Operating Systems** — add **OpenBSD** (OpenBSD 7.8 now builds the full Gershwin system, per the OpenBSD CI job in #33).
2. **Build targets** (new section, bottom of README) — document `make install` plus the granular per-component targets: `corelibs`, `workspace`, `systempreferences`, `eau-theme`, `terminal`, `textedit`, `windowmanager`, `components`. Notes that per-component targets need `make corelibs` first.
3. **Skipping repositories during checkout** (new section) — document `SKIP_REPOS` for `Checkout.sh` (space/comma-separated repo names to skip), with the symlink-in-CI use case.

No code changes; `[skip ci]` keeps the long emulated build matrix from running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)