### PR TITLE
corelibs: fix NextBSD build — mDNS zeroconf backend + libdispatch BlocksRuntime NEEDED

### DIFF
--- a/Library/OSSupport/nextbsd.txt
+++ b/Library/OSSupport/nextbsd.txt
@@ -38,3 +38,4 @@ automake
 libtool
 libvncserver
 freerdp
+patchelf

--- a/Library/Scripts/Install-System-Domain.sh
+++ b/Library/Scripts/Install-System-Domain.sh
@@ -116,6 +116,23 @@ build_corelibs() {
   "$MAKE_CMD" -j"$CPUS" || exit 1
   "$MAKE_CMD" install || exit 1
 
+  if [ "$NEXTBSD" -eq 1 ]; then
+    # swift-corelibs-libdispatch's bundled BlocksRuntime is built with no
+    # soname, so libdispatch.so records a build-tree-RELATIVE DT_NEEDED
+    # (../libBlocksRuntime.so). A NEEDED containing '/' is resolved against the
+    # running process's current directory (RUNPATH is ignored for it), so any
+    # GNUstep tool executed from a build subdirectory — or an app launched from
+    # the wrong CWD — dies with:
+    #     ld-elf.so.1: Cannot open "../libBlocksRuntime.so"
+    # (this breaks the libs-gui build at the GSspell.service step). Normalize
+    # the NEEDED to the bare soname and set RUNPATH=$ORIGIN so it resolves next
+    # to libdispatch.so in /System/Library/Libraries, where the bundled
+    # libBlocksRuntime.so is installed. Requires patchelf (see nextbsd.txt).
+    patchelf --replace-needed ../libBlocksRuntime.so libBlocksRuntime.so \
+      /System/Library/Libraries/libdispatch.so
+    patchelf --set-rpath '$ORIGIN' /System/Library/Libraries/libdispatch.so
+  fi
+
   # Build tools-make - can now find _Block_copy in libdispatch's BlocksRuntime
   # Use libobjc_LIBS=" " to prevent configure from adding -lobjc to link tests
   echo "Building/installing tools-make..."
@@ -193,11 +210,24 @@ build_corelibs() {
 
   cd "$REPOS_DIR/libs-base"
   if [ "$NEXTBSD" -eq 1 ]; then
+    # NextBSD ships libdns_sd (the mDNSResponder DNS-SD client) in
+    # /usr/lib/system, which is on binaries' runtime RUNPATH but is NOT a
+    # default link-time search dir. Without -L/usr/lib/system, libs-base
+    # configure's AC_CHECK_LIB(dns_sd, DNSServiceBrowse) link test fails, so
+    # HAVE_MDNS is set to 0 and NSNetServiceBrowser/NSNetService are built with
+    # NO zeroconf backend: their +allocWithZone: then returns nil and the
+    # [[NSNetServiceBrowser alloc] init] in the Network view SIGSEGVs
+    # (Workspace, NetworkBrowser, RemoteDesktop). Adding the -L makes the mDNS
+    # backend detect+link. /System/Library/Libraries is listed FIRST so
+    # dispatch/objc/BlocksRuntime keep linking from the Gershwin (non-Mach)
+    # domain; /usr/lib/system is only for the base-only libdns_sd. Runtime
+    # dispatch resolution is unchanged (governed by RUNPATH, verified via ldd).
     ./configure \
       $BUILD_FLAG \
       --with-dispatch-include=/usr/include \
       --with-dispatch-library=/System/Library/Libraries \
-      --with-zeroconf-api=mdns
+      --with-zeroconf-api=mdns \
+      LDFLAGS="-L/System/Library/Libraries -L/usr/lib/system"
   else
     ./configure \
       --with-dispatch-include=/System/Library/Headers \


### PR DESCRIPTION
Two NextBSD-only fixes in `build_corelibs()` (`Library/Scripts/Install-System-Domain.sh`), both required for the Gershwin domain to build a working, non-crashing image on NextBSD. Both are strictly gated by `if [ "$NEXTBSD" -eq 1 ]`, so **Linux / FreeBSD-ports builds are untouched**.

## 1. libdispatch BlocksRuntime relative `DT_NEEDED`
swift-corelibs-libdispatch's **bundled BlocksRuntime is built with no soname**, so `libdispatch.so` records a build-tree **relative** `DT_NEEDED` of `../libBlocksRuntime.so`. A `NEEDED` containing `/` is resolved against the running process's **CWD** (RUNPATH is ignored for it), so any GNUstep tool run from a build subdir — or an app launched from the wrong CWD — dies with:
```
ld-elf.so.1: Cannot open "../libBlocksRuntime.so"
```
This breaks the libs-gui build at the `GSspell.service` step. **Fix:** after `make install`, normalize the `NEEDED` to the bare soname and set `RUNPATH=$ORIGIN` via `patchelf`, so it resolves next to `libdispatch.so` in `/System/Library/Libraries`. Adds `patchelf` to `Library/OSSupport/nextbsd.txt`.

## 2. libs-base mDNS zeroconf backend
NextBSD ships `libdns_sd` (the mDNSResponder client) in `/usr/lib/system`, which is on binaries' runtime RUNPATH but **not** a default link-time search dir. Without `-L/usr/lib/system`, libs-base `configure`'s `AC_CHECK_LIB(dns_sd, DNSServiceBrowse)` link test fails → `HAVE_MDNS=0` → `NSNetServiceBrowser`/`NSNetService` are built with **no backend**. Their `+allocWithZone:` then returns `nil`, and `[[NSNetServiceBrowser alloc] init]` in the Network view **SIGSEGVs** (Workspace, NetworkBrowser, RemoteDesktop — a libobjc2 `objc_alloc_init` nil-deref).

**Fix:** add `LDFLAGS="-L/System/Library/Libraries -L/usr/lib/system"` to the libs-base `configure`. This makes the mDNS backend detect + link (network discovery now actually works). `/System/Library/Libraries` is listed **first** so `dispatch`/`objc`/`BlocksRuntime` keep linking from the Gershwin non-Mach domain; runtime dispatch resolution is unchanged (RUNPATH-governed, verified via `ldd`).

## Verification (on NextBSD)
- `ldd libdispatch.so` → resolves `libBlocksRuntime.so` from `/System/Library/Libraries`; GNUstep tools run from any CWD.
- `nm -D libgnustep-base.so` → now exports `GSMDNSNetServiceBrowser` (backend compiled in).
- Workspace's Network view no longer crashes; discovery is live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)