### PR TITLE
Add patch to Debian-family build dependencies

### DIFF
--- a/Library/OSSupport/debian.txt
+++ b/Library/OSSupport/debian.txt
@@ -18,6 +18,7 @@ flite
 libxt-dev
 portaudio19-dev
 make
+patch
 cmake
 openssl
 freeglut3-dev


### PR DESCRIPTION
## Problem

The build requires the `patch` tool but never declares it as a dependency. `Install-System-Domain.sh` applies source patches through `Library/Patches/apply_*_patch.sh`, each of which runs `patch -p1 -N` (e.g. `apply_swift-corelibs-libdispatch_patch.sh`, the libdispatch timer-spin fix). Yet `OSSupport/debian.txt` lists only `patchelf` — a different tool — not `patch`.

On a system where `patch` isn't installed transitively, the patch step silently fails and `patch` is missing from the resulting image. This surfaced in `gershwin-on-devuan`, whose `build.sh` bootstraps with `debootstrap --variant=minbase` (minimal — doesn't pull `patch`). The `gershwin-on-debian` build uses `live-build`'s fuller default package set, which included `patch` incidentally and masked the gap.

## Fix

Add `patch` to `OSSupport/debian.txt`. Since `devuan.txt` and `ubuntu.txt` are symlinks to `debian.txt`, this fixes every Debian-family build (debian, devuan, ubuntu) at the source — both the build-time patch step and the tool's presence in the final image.

## Related

Supersedes gershwin-desktop/gershwin-on-devuan#6 (which worked around this in the devuan ISO's `packages.list`); that PR is being closed in favor of this root-cause fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)