### PR TITLE
Add xprop and harden system domain installation

### DIFF
--- a/Library/OSSupport/arch.txt
+++ b/Library/OSSupport/arch.txt
@@ -29,6 +29,7 @@ libxcb
 xcb-util-cursor
 xcb-util-wm
 xorg-xrandr
+xorg-xprop
 libxrandr
 wget
 cups

--- a/Library/OSSupport/freebsd.txt
+++ b/Library/OSSupport/freebsd.txt
@@ -26,6 +26,7 @@ xcb-util-cursor
 xcb-util
 xcb-util-wm
 xrandr
+xprop
 libXrandr
 wget
 curl

--- a/Library/OSSupport/nextbsd.txt
+++ b/Library/OSSupport/nextbsd.txt
@@ -26,6 +26,7 @@ xcb-util-cursor
 xcb-util
 xcb-util-wm
 xrandr
+xprop
 libXrandr
 wget
 curl

--- a/Library/Scripts/functions.sh
+++ b/Library/Scripts/functions.sh
@@ -54,8 +54,19 @@ get_cpu_count() {
     echo "$CPU_COUNT"
 }
 
+ensure_admin_path() {
+    for DIR in /usr/local/sbin /usr/sbin /sbin; do
+        case ":$PATH:" in
+            *":$DIR:"*) ;;
+            *) PATH="${PATH:+$PATH:}$DIR" ;;
+        esac
+    done
+    export PATH
+}
+
 # Export shared environment
 export_vars() {
+    ensure_admin_path
     export WORKDIR="$(pwd)"
     export REPOS_DIR="$WORKDIR/Library/Sources"
     export CPUS="$(get_cpu_count)"

--- a/Library/Scripts/install-system-domain.sh
+++ b/Library/Scripts/install-system-domain.sh
@@ -56,16 +56,29 @@ ensure_gnustep_env() {
     exit 1
   fi
   . /System/Library/Makefiles/GNUstep.sh
+  ensure_admin_path
   export GNUSTEP_INSTALLATION_DOMAIN="SYSTEM"
+}
+
+fix_gnustep_preferences_permissions() {
+  PREFS_DIR=/System/Library/Preferences
+
+  if [ ! -d "$PREFS_DIR" ]; then
+    return 0
+  fi
+
+  find "$PREFS_DIR" -type f \( -name '*.plist' -o -name 'GNUstep.conf' \) -exec chmod go-w {} +
 }
 
 build_corelibs() {
   cd "$REPOS_DIR/gershwin-system"
   $MAKE_CMD install
+  fix_gnustep_preferences_permissions
   export GNUSTEP_INSTALLATION_DOMAIN="SYSTEM"
 
   cd "$REPOS_DIR/gershwin-assets"
   cp -R Library/* /System/Library/
+  fix_gnustep_preferences_permissions
 
   # Patch libdispatch (FreeBSD timer-spin fix; harmless on other platforms).
   echo "Patching libdispatch..."
@@ -142,8 +155,10 @@ build_corelibs() {
     libobjc_LIBS=" "
   $MAKE_CMD || exit 1
   $MAKE_CMD install
+  fix_gnustep_preferences_permissions
 
   . /System/Library/Makefiles/GNUstep.sh
+  ensure_admin_path
 
   # Build libobjc2 - gnustep-config now available for paths
   echo "Building/installing libobjc2..."


### PR DESCRIPTION
- Add xprop to platform dependency lists
- Ensure admin paths are available during install
- Tighten GNUstep preferences permissions after install steps