### PR TITLE
checkout.sh: optional BRANCH to prefer a feature branch per-repo

### DIFF
--- a/Library/Scripts/checkout.sh
+++ b/Library/Scripts/checkout.sh
@@ -3,6 +3,12 @@ set -e
 
 # Enable pinned commits with:
 #   PINNED=1 ./Library/Scripts/checkout.sh
+#
+# Build against a feature branch where it exists (e.g. a "dev" channel) with:
+#   BRANCH=dev ./Library/Scripts/checkout.sh
+# For each repo that HAS the branch on its remote it is cloned/checked out;
+# repos without it fall back to their default branch. Unset (the default)
+# leaves behaviour identical to before.
 
 PINNED="${PINNED:-0}"
 
@@ -12,6 +18,12 @@ PINNED="${PINNED:-0}"
 # the repo under test.
 SKIP_REPOS="${SKIP_REPOS:-}"
 SKIP_REPOS=$(printf '%s' "$SKIP_REPOS" | tr ',' ' ')
+
+# Optional branch to prefer for every repo that has it (e.g. BRANCH=dev). A repo
+# without the branch silently falls back to its default branch, so a partial
+# rollout works. Independent of PINNED: the pinned upstream libs don't carry
+# such a branch, so their pins are unaffected.
+BRANCH="${BRANCH:-}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPOS_DIR="$SCRIPT_DIR/../Sources"
@@ -54,13 +66,24 @@ for REPO in $REPOS; do
         (
             cd "$NAME"
             git fetch --all --tags
+            # Switch to $BRANCH if this repo has it; otherwise stay put.
+            if [ -n "$BRANCH" ] && git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
+                echo "  $NAME: switching to branch '$BRANCH'"
+                git checkout "$BRANCH"
+            fi
             if [ "$PINNED" -eq 0 ]; then
                 git pull --ff-only
             fi
         )
     else
         echo "Cloning $NAME..."
-        git clone "$REPO"
+        # Clone $BRANCH if this repo has it; otherwise the default branch.
+        BR=""
+        if [ -n "$BRANCH" ] && git ls-remote --exit-code --heads "$REPO" "$BRANCH" >/dev/null 2>&1; then
+            BR="$BRANCH"
+            echo "  $NAME: using branch '$BRANCH'"
+        fi
+        git clone ${BR:+--branch "$BR"} "$REPO"
     fi
 done
 

--- a/Library/Scripts/checkout.sh
+++ b/Library/Scripts/checkout.sh
@@ -24,6 +24,7 @@ SKIP_REPOS=$(printf '%s' "$SKIP_REPOS" | tr ',' ' ')
 # rollout works. Independent of PINNED: the pinned upstream libs don't carry
 # such a branch, so their pins are unaffected.
 BRANCH="${BRANCH:-}"
+ON_BRANCH=""     # repos actually placed on $BRANCH (for the end-of-run summary)
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPOS_DIR="$SCRIPT_DIR/../Sources"
@@ -61,15 +62,28 @@ for REPO in $REPOS; do
             ;;
     esac
 
+    # Resolve which branch to use for this repo. $BRANCH is generic — any branch
+    # name works (e.g. BRANCH=dev, or a feature branch you want to test). Probed
+    # in the parent shell (not a subshell) so we can print a summary at the end.
+    # A repo that doesn't have the branch falls back to its default branch.
+    USE_BRANCH=""
+    if [ -n "$BRANCH" ]; then
+        if git ls-remote --exit-code --heads "$REPO" "$BRANCH" >/dev/null 2>&1; then
+            USE_BRANCH="$BRANCH"
+            ON_BRANCH="$ON_BRANCH $NAME"
+        else
+            echo "  $NAME: no '$BRANCH' branch — using default branch"
+        fi
+    fi
+
     if [ -d "$NAME/.git" ]; then
         echo "Updating $NAME..."
         (
             cd "$NAME"
             git fetch --all --tags
-            # Switch to $BRANCH if this repo has it; otherwise stay put.
-            if [ -n "$BRANCH" ] && git show-ref --verify --quiet "refs/remotes/origin/$BRANCH"; then
-                echo "  $NAME: switching to branch '$BRANCH'"
-                git checkout "$BRANCH"
+            if [ -n "$USE_BRANCH" ]; then
+                echo "  $NAME: checking out branch '$USE_BRANCH'"
+                git checkout "$USE_BRANCH"
             fi
             if [ "$PINNED" -eq 0 ]; then
                 git pull --ff-only
@@ -77,15 +91,21 @@ for REPO in $REPOS; do
         )
     else
         echo "Cloning $NAME..."
-        # Clone $BRANCH if this repo has it; otherwise the default branch.
-        BR=""
-        if [ -n "$BRANCH" ] && git ls-remote --exit-code --heads "$REPO" "$BRANCH" >/dev/null 2>&1; then
-            BR="$BRANCH"
-            echo "  $NAME: using branch '$BRANCH'"
+        if [ -n "$USE_BRANCH" ]; then
+            echo "  $NAME: cloning branch '$USE_BRANCH'"
         fi
-        git clone ${BR:+--branch "$BR"} "$REPO"
+        git clone ${USE_BRANCH:+--branch "$USE_BRANCH"} "$REPO"
     fi
 done
+
+# Summary of which repos were placed on $BRANCH (only when BRANCH is in play).
+if [ -n "$BRANCH" ]; then
+    if [ -n "$ON_BRANCH" ]; then
+        echo "Branch '$BRANCH' used for:$ON_BRANCH"
+    else
+        echo "No repository has a '$BRANCH' branch — all on their default branch."
+    fi
+fi
 
 # Apply pinned commits if requested
 if [ "$PINNED" -eq 1 ]; then

--- a/README.md
+++ b/README.md
@@ -102,3 +102,27 @@ CI checkout of the component under test, symlinked into `Library/Sources/`):
 ```
 SKIP_REPOS="gershwin-workspace gershwin-terminal" /Developer/Library/Scripts/checkout.sh
 ```
+
+## Building against a development or feature branch
+
+By default `checkout.sh` clones each repository's default branch. Set `BRANCH`
+to build against another branch instead — most commonly a `dev` branch holding
+work in progress *before it lands in the default branch*:
+
+```
+BRANCH=dev /Developer/Library/Scripts/checkout.sh
+```
+
+`BRANCH` is generic — any branch name works — so it doubles as a tool for
+testing a feature branch across repositories:
+
+```
+BRANCH=my-feature /Developer/Library/Scripts/checkout.sh
+```
+
+For each repository that **has** the named branch, it is cloned/checked out on
+that branch; repositories **without** it fall back to their default branch, so a
+partial rollout (where only some repos have the branch yet) just works. The run
+logs which repository used the branch and prints a summary at the end. Leaving
+`BRANCH` unset keeps the previous behaviour, and `BRANCH` can be combined with
+`PINNED` and `SKIP_REPOS`.


### PR DESCRIPTION
## What

Adds an optional, **generic** `BRANCH` env var to `Library/Scripts/checkout.sh`:

```sh
BRANCH=dev ./Library/Scripts/checkout.sh        # the dev channel (primary use)
BRANCH=my-feature ./Library/Scripts/checkout.sh # or any branch, for testing
```

For each repo that **has** `$BRANCH` on its remote, it is cloned/checked out on that branch; repos **without** it fall back to their default branch. `BRANCH` is not hardcoded to `dev` — any branch name works, so it doubles as a tool for testing a feature branch across repos before it lands.

## Why

Prerequisite for a **dev** release channel (build the work-in-progress `dev` branches) in the gershwin-desktop ISO monorepo, alongside the existing/rc channel — without forking the checkout script.

## Behaviour / safety

- **`BRANCH` unset ⇒ byte-for-byte the previous behaviour** — cannot affect current/rc builds.
- **Per-repo fallback** — a missing branch is never an error; a partial rollout (only some repos have the branch yet) just works.
- **Independent of `PINNED` / `SKIP_REPOS`** — pinned upstream libs carry no such branch, so their pins are untouched; combinable with both.
- Both the clone and update code paths handled.

## Verbosity

Logs per repo whether it used `$BRANCH` or fell back to default, and prints a summary, e.g.:

```
  gershwin-workspace: cloning branch 'dev'
  libs-base: no 'dev' branch — using default branch
  ...
Branch 'dev' used for: gershwin-workspace gershwin-terminal ...
```

## Docs

README.md gains a "Building against a development or feature branch" section (dev channel as the lead example, plus the generic feature-branch usage).

## Test

`sh -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)