### PR TITLE
checkout.sh: pin upstream libraries by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
           run: |
             set -e
             ./Library/Scripts/bootstrap.sh
-            PINNED=1 ./Library/Scripts/checkout.sh
+            ./Library/Scripts/checkout.sh
             make install
             mkdir -p artifacts/FreeBSD/14/amd64
             tar -C / -cJf artifacts/FreeBSD/14/amd64/system.txz /System
@@ -63,7 +63,7 @@ jobs:
         run: ./Library/Scripts/bootstrap.sh
 
       - name: Checkout sources
-        run: PINNED=1 ./Library/Scripts/checkout.sh
+        run: ./Library/Scripts/checkout.sh
 
       - name: Build and install
         run: make install
@@ -105,7 +105,7 @@ jobs:
         run: ./Library/Scripts/bootstrap.sh
 
       - name: Checkout sources
-        run: PINNED=1 ./Library/Scripts/checkout.sh
+        run: ./Library/Scripts/checkout.sh
 
       - name: Build and install
         run: make install
@@ -152,7 +152,7 @@ jobs:
           run: |
             set -e
             ./Library/Scripts/bootstrap.sh
-            PINNED=1 ./Library/Scripts/checkout.sh
+            ./Library/Scripts/checkout.sh
             make install
             mkdir -p artifacts/OpenBSD/7.8/amd64
             # OpenBSD's base tar has no -J (xz); use -z (gzip), which it supports.

--- a/Library/Scripts/checkout.sh
+++ b/Library/Scripts/checkout.sh
@@ -56,14 +56,17 @@ https://github.com/gershwin-desktop/gershwin-assets.git
 # them so we don't develop against a moving target and so the patches under
 # Library/Patches/ keep applying. Every entry here must be a non-Gershwin repo —
 # Gershwin's own repositories track their branch and are deliberately absent.
+# Refreshed 2026-07-26. Every patch under Library/Patches/ was dry-run against
+# these commits. libs-gui is held a day behind its HEAD: dropdown-tracking.patch
+# does not apply to the 2026-07-26 commits.
 PINS="
-libobjc2                    4148a3d
-libs-back                   bf3b3ce # Patch by okt
-libs-base                   caa0816
-libs-gui                    8be638c
-swift-corelibs-libdispatch  4876f91
-tools-make                  50cf961
-libs-av                     922d3c3
+libobjc2                    c9f4002
+libs-back                   bbcc3de
+libs-base                   5bda522
+libs-gui                    8f804fd
+swift-corelibs-libdispatch  95f592a
+tools-make                  4e31a03
+libs-av                     26566e2
 libs-steptalk               2b57b46
 "
 

--- a/Library/Scripts/checkout.sh
+++ b/Library/Scripts/checkout.sh
@@ -1,8 +1,11 @@
 #!/bin/sh
 set -e
 
-# Enable pinned commits with:
-#   PINNED=1 ./Library/Scripts/checkout.sh
+# The upstream (non-Gershwin) libraries are pinned by default, so the tree we
+# build is the tree Library/Patches/ was written against. Track their moving
+# HEADs instead — e.g. to check whether a pin can be advanced — with:
+#   PINNED=0 ./Library/Scripts/checkout.sh
+# Gershwin's own repositories are never pinned; they always track their branch.
 #
 # Build against a feature branch where it exists (e.g. a "dev" channel) with:
 #   BRANCH=dev ./Library/Scripts/checkout.sh
@@ -10,7 +13,7 @@ set -e
 # repos without it fall back to their default branch. Unset (the default)
 # leaves behaviour identical to before.
 
-PINNED="${PINNED:-0}"
+PINNED="${PINNED:-1}"
 
 # Repositories to skip cloning/updating, given as a space- or comma-separated
 # list of repo names (e.g. SKIP_REPOS="gershwin-workspace"). Useful when the
@@ -49,6 +52,31 @@ https://github.com/gershwin-desktop/gershwin-components.git
 https://github.com/gershwin-desktop/gershwin-assets.git
 "
 
+# Pinned commits, as "<repo name> <commit>". These are upstream libraries; we pin
+# them so we don't develop against a moving target and so the patches under
+# Library/Patches/ keep applying. Every entry here must be a non-Gershwin repo —
+# Gershwin's own repositories track their branch and are deliberately absent.
+PINS="
+libobjc2                    4148a3d
+libs-back                   bf3b3ce # Patch by okt
+libs-base                   caa0816
+libs-gui                    8be638c
+swift-corelibs-libdispatch  4876f91
+tools-make                  50cf961
+libs-av                     922d3c3
+libs-steptalk               2b57b46
+"
+
+# Echo the pinned commit for repo $1, or nothing if the repo is not pinned.
+pin_for() {
+    echo "$PINS" | while read -r _name _commit _rest; do
+        if [ "$_name" = "$1" ]; then
+            echo "$_commit"
+            break
+        fi
+    done
+}
+
 mkdir -p "$REPOS_DIR"
 cd "$REPOS_DIR"
 
@@ -76,6 +104,13 @@ for REPO in $REPOS; do
         fi
     fi
 
+    # Only a repo that is about to be moved onto a pin skips the pull; everything
+    # else (all of Gershwin's own repos) still fast-forwards as it always did.
+    PIN=""
+    if [ "$PINNED" -eq 1 ]; then
+        PIN=$(pin_for "$NAME")
+    fi
+
     if [ -d "$NAME/.git" ]; then
         echo "Updating $NAME..."
         (
@@ -85,7 +120,23 @@ for REPO in $REPOS; do
                 echo "  $NAME: checking out branch '$USE_BRANCH'"
                 git checkout "$USE_BRANCH"
             fi
-            if [ "$PINNED" -eq 0 ]; then
+            if [ -z "$PIN" ]; then
+                # An earlier pinned run leaves the repo on a detached HEAD, and
+                # --ff-only then has no branch to advance. Put it back on its
+                # default branch first, so PINNED=0 un-pins an existing tree
+                # rather than silently leaving it at the old pin.
+                if [ -z "$USE_BRANCH" ] && ! git symbolic-ref -q HEAD >/dev/null; then
+                    DEFAULT_BRANCH=$(git symbolic-ref -q --short refs/remotes/origin/HEAD || true)
+                    if [ -z "$DEFAULT_BRANCH" ]; then
+                        git remote set-head origin -a >/dev/null 2>&1 || true
+                        DEFAULT_BRANCH=$(git symbolic-ref -q --short refs/remotes/origin/HEAD || true)
+                    fi
+                    DEFAULT_BRANCH="${DEFAULT_BRANCH#origin/}"
+                    if [ -n "$DEFAULT_BRANCH" ]; then
+                        echo "  $NAME: detached — returning to '$DEFAULT_BRANCH'"
+                        git checkout "$DEFAULT_BRANCH"
+                    fi
+                fi
                 git pull --ff-only
             fi
         )
@@ -107,40 +158,37 @@ if [ -n "$BRANCH" ]; then
     fi
 fi
 
-# Apply pinned commits if requested
+# Apply the pinned commits (the default; PINNED=0 opts out). A repo listed in
+# SKIP_REPOS was never cloned here, so it has nothing to pin.
 if [ "$PINNED" -eq 1 ]; then
     echo "Checking out pinned commits..."
 
-    checkout_commit() {
-        REPO="$1"
-        COMMIT="$2"
+    # Fed by redirection rather than a pipe so `set -e` still applies to the body.
+    while read -r NAME COMMIT _rest; do
+        [ -n "$NAME" ] || continue
+        [ -d "$NAME/.git" ] || continue
+        echo "  $NAME -> $COMMIT"
         (
-            cd "$REPO"
+            cd "$NAME"
             git checkout "$COMMIT"
         )
-    }
-    # These are upstream libraries, we pin them in order to not develop for a moving target
-    checkout_commit libobjc2                     4148a3d
-    checkout_commit libs-back                    bf3b3ce # Patch by okt
-    checkout_commit libs-base                    caa0816
-    checkout_commit libs-gui                     8be638c
-    checkout_commit swift-corelibs-libdispatch   4876f91
-    checkout_commit tools-make                   50cf961
-    checkout_commit libs-av                      922d3c3
-    checkout_commit libs-steptalk                2b57b46
-
+    done <<EOF
+$PINS
+EOF
 fi
 
-# The following do not seeem to be causing showstoppers currently
-# checkout_commit gershwin-windowmanager       1f3cc1c
-# checkout_commit gershwin-components          3395d99
-# checkout_commit gershwin-eau-theme           4babcb0
-# checkout_commit gershwin-assets              4deb482
-# checkout_commit gershwin-workspace           1bc3b98
-# checkout_commit gershwin-system              cdeafb6
-# checkout_commit gershwin-systempreferences   8d49f50
-# checkout_commit gershwin-terminal            71124e3
-# checkout_commit gershwin-textedit            3df6db8
+# Gershwin's own repositories are intentionally NOT in $PINS: pinning them would
+# mean the build no longer picks up our own work. These commits are kept only as
+# a record of a known-good set. Do not move them into $PINS.
+# gershwin-windowmanager       1f3cc1c
+# gershwin-components          3395d99
+# gershwin-eau-theme           4babcb0
+# gershwin-assets              4deb482
+# gershwin-workspace           1bc3b98
+# gershwin-system              cdeafb6
+# gershwin-systempreferences   8d49f50
+# gershwin-terminal            71124e3
+# gershwin-textedit            3df6db8
 
 # Lower CMake version requirements
 # Use a temp-file approach for in-place sed to avoid -i portability issues

--- a/README.md
+++ b/README.md
@@ -92,6 +92,26 @@ make corelibs
 make workspace
 ```
 
+## Pinned upstream libraries
+
+The upstream libraries (`libobjc2`, `tools-make`, `libs-base`, `libs-gui`,
+`libs-back`, `libs-av`, `libs-steptalk`, `swift-corelibs-libdispatch`) are
+checked out at pinned commits by default, so that the sources we build are the
+sources the patches in `Library/Patches/` were written against. Without the pins
+an upstream commit can silently break a patch and fail the build.
+
+Gershwin's own repositories are **never** pinned — they always track their
+branch, so the build picks up our work as it lands.
+
+To check whether a pin can be advanced, build against the upstream HEADs
+instead:
+
+```
+PINNED=0 /Developer/Library/Scripts/checkout.sh
+```
+
+The pins live in the `PINS` list at the top of `checkout.sh`.
+
 ## Skipping repositories during checkout
 
 `checkout.sh` clones every repository the build needs. Set `SKIP_REPOS` to a


### PR DESCRIPTION
## Why

`PINNED` defaulted to `0`, so pinning only happened where a caller remembered to ask for it. In `gershwin-desktop` only the **debian** target does — `nextbsd`, `freebsd`, `archlinux` and `devuan` all call `checkout.sh` unpinned and build the upstream libs at HEAD.

`Library/Patches/` is written against the pins, so a moving upstream HEAD silently breaks a patch. That is the failure in [run 30229524261](https://github.com/gershwin-desktop/gershwin-desktop/actions/runs/30229524261/job/89868742756) (`libs-gui: failed`). Dry-running the patches against both trees:

| patch | @ pinned | @ HEAD |
|---|---|---|
| `libs-gui/dropdown-tracking.patch` | ✅ | ❌ **fails** |
| `libs-gui/menu-transient.patch` | ✅ | ✅ |
| `libs-back/inter-bold.patch` | ✅ | ✅ |
| `libs-back/net-wm-pid.patch` | ✅ | ✅ |
| `libs-av/metadata.patch` | ✅ | ✅ |
| `swift-corelibs-libdispatch/fix-timer-spin.patch` | ✅ | ✅ |

(The blank line under `dropdown-tracking.patch...` in the CI log is `patch.sh`'s empty `$err` — `patch` writes its failure detail to stdout, which `patch.sh` discards. `menu-transient.patch` is not the culprit.)

## What

- `PINNED` now defaults to **1**; `PINNED=0` is the opt-out for checking whether a pin can be advanced. This fixes every unpinned caller at once, so the other `gershwin-desktop` targets need no change.
- The redundant `PINNED=1` added to this repo's own CI in e792d19 is dropped again.
- The pins move into a `PINS` list, so the pin checkout and the skip-the-pull logic derive from one source.

Two consequences of the flip are handled:

- **The pull skip was keyed on `PINNED`, not on whether the repo is pinned.** Defaulting to 1 would have stopped *Gershwin's own* repos from fast-forwarding in an existing tree. Now keyed on the repo actually having a pin.
- **A pinned run leaves a repo detached**, so `--ff-only` had nothing to advance and `PINNED=0` could not un-pin an existing tree. An unpinned repo found detached is returned to its default branch before pulling.

## Non-Gershwin repos only

`PINS` contains exactly the 8 upstream libraries — `libobjc2`, `tools-make`, `libs-base`, `libs-gui`, `libs-back`, `libs-av`, `libs-steptalk`, `swift-corelibs-libdispatch`. **No Gershwin repository is pinned.** The old `gershwin-*` commits stay commented out, now with a note saying not to move them into `PINS`.

## Testing

`sh -n` clean. Ran the real script against a reduced repo set (one pinned lib, one Gershwin repo):

- fresh clone, defaults → upstream lib detached at its pin, Gershwin repo on its branch tip
- re-run after rolling the Gershwin repo back 3 commits → fast-forwards to tip (this is the regression the flip would otherwise have introduced), pinned lib stays at its pin
- `PINNED=0` on a tree left detached by a pinned run → returns to `master` and pulls; re-running with defaults re-pins
- `BRANCH=dev` + default pinning (the combo CI uses) → Gershwin repo on `dev`, upstream lib falls back to default branch and then pins

Nothing here rebuilds the ISO, so the nextbsd job is the real check.


---

## Update: the pins themselves were stale

Turning pinning on everywhere exposed a second problem — several pins had drifted far enough that they no longer build. `libs-base` was pinned at `caa0816` (2026-03) and fails configure against Arch's current clang:

```
checking if the compiler supports -fconstant-string-class... no
configure: error: Your compiler does not appear to implement the
-fconstant-string-class option needed for support of strings.
```

This is why the Arch job fails; it fails on `dev` too ([run 30223956176](https://github.com/gershwin-desktop/gershwin-developer/actions/runs/30223956176)), independently of this branch.

Every pin is now advanced to its current upstream HEAD, with one exception:

| repo | old | new | move |
|---|---|---|---|
| `libobjc2` | `4148a3d` | `c9f4002` | +24 |
| `libs-back` | `bf3b3ce` | `bbcc3de` | +87 |
| `libs-base` | `caa0816` | `5bda522` | +246 |
| **`libs-gui`** | `8be638c` | **`8f804fd`** | +1001 |
| `swift-corelibs-libdispatch` | `4876f91` | `95f592a` | +11 |
| `tools-make` | `50cf961` | `4e31a03` | +9 |
| `libs-av` | `922d3c3` | `26566e2` | +2 |
| `libs-steptalk` | `2b57b46` | unchanged | already HEAD |

**`libs-gui` is deliberately held at the last commit of 2026-07-25**, not its HEAD: `dropdown-tracking.patch` stops applying somewhere in the 2026-07-26 commits. Every commit in the 07-24/25 window takes both patches cleanly, so `8f804fd` is a day behind rather than six months behind.

All six patches were dry-run against the new pins and apply: `libs-gui` dropdown-tracking + menu-transient, `libs-back` inter-bold + net-wm-pid, `libs-av` metadata, `libdispatch` fix-timer-spin. Every move is a fast-forward.

`libs-av` goes to `26566e2`, which 97c8fda reverted — that revert was about dropping `capture.patch` (Whisper uses the ffmpeg CLI), not about the commit itself, and `metadata.patch` applies. Say the word if you'd rather leave that pin alone.

### CI

[Run 30231871436](https://github.com/gershwin-desktop/gershwin-developer/actions/runs/30231871436) is green on all four: FreeBSD, Debian, OpenBSD and **Arch** — which was red on `dev` before this branch.
